### PR TITLE
change ci file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: objective-c
 osx_image: xcode7.1.1
 xcode_project: startiosdev.xcodeproj
 xcode_scheme: startiosdev
-xcode_sdk: iphonesimulator9.1
+#xcode_sdk: iphonesimulator9.1


### PR DESCRIPTION
ERROR: SDK 'iphonesimulator9.1' doesn't exist.  Possible SDKs include:
macosx, iphoneos, macosx10.9, macosx10.10, iphonesimulator,
iphoneos8.1, iphonesimulator7.1, iphonesimulator8.1, iphonesimulator7.0
